### PR TITLE
Add Cobblestone Legacy docs and status dashboard

### DIFF
--- a/docs/cobblestone/_category_.json
+++ b/docs/cobblestone/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Cobblestone Legacy",
+  "position": 1,
+  "collapsed": false
+}

--- a/docs/cobblestone/concept-framework.md
+++ b/docs/cobblestone/concept-framework.md
@@ -1,0 +1,65 @@
+---
+id: concept-framework
+slug: /cobblestone/concept-framework
+title: Concept Framework
+sidebar_label: Concept Framework
+---
+
+> "From the streets, a legacy rises."
+
+Cobblestone Legacy is a sandbox RPG with rogue-lite elements set inside a living, procedurally generated Victorian city. You begin as a 12-year-old orphan and must survive, grow, and ultimately shape the fate of Grimborough through the choices you make, the factions you court, and the risks you take.
+
+## Core Pillars
+
+### Survival Mechanics
+- Track stamina, energy, thirst, and hunger to stay alive in a harsh city with limited resources.
+- Rest, sleep, forage, or tinker to recover vital stats and discover new opportunities.
+
+### Exploration & Discovery
+- Fog of war obscures the city and encourages scouting.
+- Discover stashes, hideouts, and key locations through rumors, tracking NPCs, and exploration.
+- Every run is unique thanks to procedural city generation.
+
+### Player Progression
+- Train skills such as stealth, lockpicking, crafting, and combat.
+- Earn experience through quests, activities, and training.
+- Unlock impactful capstone abilities when maxing a skill.
+
+### Faction Dynamics
+- Ally with, sabotage, or betray competing factions.
+- Reputation and infamy shape access to resources, perks, and quests.
+- A reactive city economy and politics respond to player actions.
+
+### Narrative Depth
+- Dialogue choices, quests, and random events weave a personal narrative.
+- NPCs remember past actions, share rumors, and expose the history of Grimborough.
+- Decide whether to help clean up the city or let it descend into chaos.
+
+## Key Features
+
+1. **Survival & Needs Management** — Deep vitals simulation with lethal consequences for neglecting food, water, or rest.
+2. **Travel & Map Systems** — Safety-aware pathfinding, travel stances, and fog of war that reveal the city piece by piece.
+3. **Skill Progression** — Training, synergies, and capstone rewards that reinforce a chosen playstyle.
+4. **Theft & Stealth** — Scout, lockpick, or break into lucrative targets while avoiding guards through stealth or parkour.
+5. **Quests & Activities** — Organic missions tied to NPCs and factions, plus a library of ambient activities and dynamic events.
+6. **Crafting & Economy** — Craft gear, trade stolen goods, and manipulate prices in a living economy.
+7. **Dynamic World** — Procedural city layouts, evolving factions, and schedule-driven NPC behaviors.
+8. **Immersive Storytelling** — Moral choices and faction relationships reverberate throughout the city.
+
+## Example Quest Hooks
+
+- Find medicine for an injured ally to unlock new information or loyalty.
+- Deliver contraband across dangerous districts.
+- Stake out a wealthy home to plan a heist, or rescue a kidnapped faction member.
+- Sabotage security systems, reclaim seized goods, or recruit new allies.
+- Protect caravans, craft rare items, or spy on rival factions for leverage.
+
+## Player Activities at a Glance
+
+- Pickpocket, scavenge, and trade to stay afloat.
+- Train stealth, crafting, acrobatics, and more to specialize.
+- Follow wealthy marks, break into buildings, and stash valuable loot.
+- Craft tools and consumables, then sell them or leverage them for bigger scores.
+- Use parkour and stealth to escape guards and rival gangs.
+
+Cobblestone Legacy is designed for 3–6 hour runs with unlockable traits, gear, and world changes that keep every playthrough fresh. Endgame goals range from faction leadership to becoming a master thief or reshaping the city as a reformer or criminal kingpin.

--- a/docs/cobblestone/narrative/_category_.json
+++ b/docs/cobblestone/narrative/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Narrative",
+  "position": 2,
+  "collapsed": false
+}

--- a/docs/cobblestone/narrative/grimborough-prologue.md
+++ b/docs/cobblestone/narrative/grimborough-prologue.md
@@ -1,0 +1,56 @@
+---
+id: grimborough-prologue
+slug: /cobblestone/narrative/grimborough-prologue
+title: Grimborough Prologue
+sidebar_label: Prologue Narrative
+---
+
+## Suggested City Names
+
+- Blackhaven
+- Ironstead
+- Duskwatch
+- Ashenford
+- Grimborough
+- Coalport
+- Hollowgate
+- Shadeport
+- Elderwynd
+
+## Opening Cinematic
+
+A black screen fades into Grimborough—an industrial city drowning in soot, gaslight, and ambition. Towers pierce the fog as smokestacks paint the sky in cinder.
+
+> "The year is 1847, and the city of Grimborough stands as a monument to progress... and despair. Its factories churn wealth for the fortunate few, while the downtrodden drown in its shadows. The air is thick with soot, the streets echo with the cries of merchants and the clatter of boots. It is a place of opportunity for some, and survival for most."
+
+## Childhood Memory
+
+Inside a humble home, loving parents cradle their newborn with hope in their eyes. They dream of a life beyond smoke and ash for their child.
+
+> "Your parents dreamed of something better for you. A life beyond the smoke and ash. For them, you were a beacon of hope in a world that had long forgotten it."
+
+## Player Name Prompt
+
+> "But remind me... what was your name again?"
+
+The player enters a name; elegant script fades in, branding the memory.
+
+## Fleeting Joy
+
+Montage of playtime on cobblestone streets, sewing scraps with mother, listening to father's stories.
+
+> "Those years were fleeting, but they were good. The laughter, the love—it seemed as though it might last forever."
+
+## Tragedy Strikes
+
+An alleyway. Two silhouettes lie still while a child kneels beside them.
+
+> "But happiness is a fragile thing in Grimborough. The city does not allow such luxuries for long. They came for your parents—thieves, desperate men, or perhaps worse. What they took was more than money, more than life itself. They took your world."
+
+## Into the Streets
+
+The screen fades to black with distant sobbing and a tolling bell.
+
+> "And so, alone and cast into the heartless streets of Grimborough, your story begins. From these shadows, what will you become? Will you rise above the filth and chaos… or will you let it consume you?"
+
+Gameplay begins with the player alone in the slums—legacy yet unwritten.

--- a/docs/cobblestone/systems/_category_.json
+++ b/docs/cobblestone/systems/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Systems",
+  "position": 1,
+  "collapsed": false
+}

--- a/docs/cobblestone/systems/dynamic-dialog.md
+++ b/docs/cobblestone/systems/dynamic-dialog.md
@@ -1,0 +1,65 @@
+---
+id: dynamic-dialog
+slug: /cobblestone/systems/dynamic-dialog
+title: Dynamic Dialog System
+sidebar_label: Dynamic Dialog System
+---
+
+## Adaptive Conversations
+
+The Dynamic Dialog System keeps every conversation grounded in context and memory.
+
+- **Memory-Driven Exchanges** — NPCs remember prior encounters and respond accordingly.
+- **Dynamic Rumors** — Dialogue reflects rumors the player sparked or unearthed, letting information spread across the city.
+- **Personalized Greetings** — NPC tone shifts with their mood, relationship score, and knowledge of your deeds.
+
+## Immersive NPC Interaction
+
+- **Reputation Awareness** — Responses adapt to faction alignment and notoriety.
+- **Mood & Disposition** — Emotional states such as friendly, neutral, or hostile flavor dialogue choices and branching paths.
+- **Faction Loyalty** — NPC allegiances influence their willingness to help, betray, or warn the player.
+
+## Quest & Event Integration
+
+- Quests begin, update, or conclude naturally inside conversations.
+- NPCs acknowledge world events—recent thefts, battles, festivals, or curfews.
+- Foresight and warnings foreshadow upcoming encounters.
+
+## Rumor System Hooks
+
+- NPCs trade gossip with accuracy that shifts as stories spread.
+- Rumors unlock quests, reveal locations, and nudge relationships in new directions.
+- Detailed metadata (participants, timestamps, reputational impact) powers investigative gameplay.
+
+## Smart Option Filtering
+
+- Dialogue options appear or hide based on reputation, mood, prior choices, or current objectives.
+- Logical progression keeps conversations fresh—no repeated loops unless context warrants it.
+
+## Modular Content Creation
+
+- JSON-driven conversation files make it easy to author, reuse, or customize dialogue at scale.
+- Shared templates with NPC-specific overrides accelerate content production.
+- Scales to hundreds of NPCs and thousands of branching options.
+
+## Interactive World Features
+
+- NPCs converse in real time, exchange rumors, and react to proximity.
+- Player choices reshape relationships, trigger events, and modify the world state.
+
+## Developer Tooling
+
+- Inspect active NPCs, conversation history, and rumor propagation in debugging views.
+- Built-in validation prevents broken conditions and tracks NPC mood, reputation, and rumor knowledge live.
+
+## Time-Aware Immersion
+
+- Dialogue reflects current in-game time, season, and scheduled events.
+- Time-gated interactions encourage planning and reinforce daily routines.
+
+## Event Hooks
+
+- Conversations can reveal map locations, spawn encounters, update inventories, or trigger custom events.
+- Fully integrated with quest, event, and inventory managers for cohesive storytelling.
+
+**Why it matters:** Immersion, flexibility, and consequence-driven dialogue turn NPCs into memorable characters whose stories evolve with the player.

--- a/docs/cobblestone/systems/dynamic-health-vitality.md
+++ b/docs/cobblestone/systems/dynamic-health-vitality.md
@@ -1,0 +1,54 @@
+---
+id: dynamic-health-vitality
+slug: /cobblestone/systems/dynamic-health-vitality
+title: Dynamic Health & Vitality System
+sidebar_label: Dynamic Health & Vitality
+---
+
+## Survival Is More Than a Health Bar
+
+The Dynamic Health & Vitality System turns every calorie burned, sip of water, and restless night into a meaningful gameplay decision. Survival stats are modeled as interconnected resources that respond to the player's habits, environment, and long-term choices.
+
+### Health & Stamina Management
+- Track health, stamina, energy, hydration, and weight simultaneously.
+- Regeneration depends on rest quality, injuries, and environment—instant heals do not exist.
+
+### Weight & Body Composition
+- Weight, fat, and muscle change based on caloric intake, physical exertion, and age.
+- Starvation, overexertion, and extreme conditions degrade performance until the player adapts or recovers.
+
+### Energy & Starvation
+- Daily caloric intake drives energy reserves; negative states trigger muscle loss and stat degradation.
+- Starvation unfolds gradually, forcing hard choices about rationing, rest, and risk.
+
+### Hydration Model
+- Hydration affects stamina recovery, coordination, and reaction time.
+- Environmental heat, humidity, and activity levels accelerate water loss.
+
+### Environment & Activity Interactions
+- Extreme weather drains vitals faster; safe zones offer accelerated recovery.
+- Activity intensity (running, climbing, hauling) determines caloric burn and fatigue.
+
+### Aging & Development
+- Characters age naturally; body composition shifts with growth and neglect.
+- Strength and endurance peak before tapering off without ongoing training.
+
+### Tactical Resource Planning
+- Food, water, and carried weight directly influence stamina and movement speed.
+- Players must balance survival gear with mobility and combat readiness.
+
+## Gameplay Impact
+
+- **Stat Evolution** — Activity raises strength and endurance, while malnutrition or dehydration erodes them.
+- **Adaptive Body Systems** — Weight and body fat fluctuate, altering stamina recovery and combat performance.
+- **World Pressure** — Weather and rest quality determine whether the city wears you down or lets you rebound.
+- **Energy & Stamina Loop** — Energy governs stamina regeneration, making retreats, rest, and preparation critical.
+
+## Unique Selling Points
+
+- Deeply integrated survival loop where the body feels tangible and reactive.
+- Progression reflects player choices and lifestyle over the course of a run.
+- Strategic resource management that elevates every scavenging trip and meal.
+- A world that reacts to your condition, making survival storytelling personal and tense.
+
+**Tagline:** _"Survive, Adapt, Overcome: Your body is your greatest asset—or your greatest weakness."_

--- a/docs/cobblestone/systems/dynamic-quest-goal-system.md
+++ b/docs/cobblestone/systems/dynamic-quest-goal-system.md
@@ -1,0 +1,30 @@
+---
+id: dynamic-quest-goal-system
+slug: /cobblestone/systems/dynamic-quest-goal-system
+title: Dynamic Quest & Goal System
+sidebar_label: Dynamic Quest & Goal System
+---
+
+## Endless Story Variants
+
+The Dynamic Quest & Goal System keeps playthroughs fresh by blending NPC-generated quests, faction missions, and player-declared ambitions.
+
+### Intent-Driven Progression
+- Players can declare personal goals such as "Become a master thief" or "Start a business."
+- Each intent spawns structured sub-quests and checkpoints tailored to that aspiration.
+
+### Personality-Aware Contracts
+- NPC personalities influence which quests they offer. Suspicious nobles avoid espionage work while desperate merchants propose smuggling or shady deals.
+- Success or failure reshapes the quest graph, unlocking new branches or closing doors permanently.
+
+### World State Integration
+- Faction standing, rumor accuracy, and economic shifts all inform available objectives.
+- Quests can evolve mid-run based on player decisions, rival activity, or global events.
+
+### Dependency Tracking
+- System tracks quest relationships to ensure cascading consequences. Missing a deadline or betraying a faction changes future opportunities.
+
+### Replayability
+- Procedural combinations of intents, NPC personalities, and world events deliver unique narratives across 3–6 hour runs.
+
+Whether you are manipulating city politics, running a criminal empire, or chasing ancient secrets, the quest system shapes itself around your story.

--- a/docs/cobblestone/systems/dynamic-rumors.md
+++ b/docs/cobblestone/systems/dynamic-rumors.md
@@ -1,0 +1,39 @@
+---
+id: dynamic-rumors
+slug: /cobblestone/systems/dynamic-rumors
+title: Dynamic Rumor System
+sidebar_label: Dynamic Rumor System
+---
+
+## Living Information Economy
+
+Rumors evolve as they travel, creating investigative gameplay and a reactive city.
+
+- **Evolving Accuracy** — Each retelling can distort locations, witnesses, and descriptions. Accuracy ranges from 0–100% and is only guaranteed when the original source is found.
+- **Degraded Details** — NPCs misplace landmarks, forget names, or embellish events depending on their personality and relationship to the source.
+- **Spread History** — Every rumor records who told whom, letting players trace the most reliable version by interviewing the network.
+
+## NPC Schedules & Presence
+
+- NPCs follow daily routines—work, errands, rest—that determine where rumors propagate.
+- Errand states send characters wandering markets or docks, creating lived-in crowds.
+- Pathfinding keeps traffic flowing realistically through districts.
+
+## Investigative Tools
+
+- **Rumor Journal** — Track all leads with source NPCs, accuracy ratings, and version numbers.
+- **Dynamic Conversations** — NPCs naturally mention rumors mid-dialogue, seeding new objectives or clues.
+- **Skill Impact** — Perception and wisdom skills improve the fidelity of information heard.
+
+## World Reactivity
+
+- Player actions seed new rumors about heroism, theft, or infamy.
+- NPCs share intel with each other, altering faction attitudes and opportunities.
+- Time-of-day awareness ensures rumors circulate differently across shifts and neighborhoods.
+
+## Selling Points
+
+1. Organic network of evolving information keeps investigations engaging.
+2. NPC ecosystem that feels alive thanks to schedules and rumor sharing.
+3. Player-driven detective gameplay—separate truth from fiction.
+4. A reputation layer where the city reacts to your deeds long before you arrive.

--- a/docs/cobblestone/systems/economy-manager.md
+++ b/docs/cobblestone/systems/economy-manager.md
@@ -1,0 +1,61 @@
+---
+id: economy-manager
+slug: /cobblestone/systems/economy-manager
+title: Economy Manager
+sidebar_label: Economy Manager
+---
+
+## Dynamic Market Simulation
+
+The Economy Manager keeps prices fluid based on supply, demand, and player influence.
+
+### Getting Started
+
+```gdscript title="Initialize the economy"
+var base_prices = {
+    "Iron": 100,
+    "Gold": 500,
+    "Wheat": 50
+}
+EconomyManager.initialize(base_prices)
+```
+
+### Supply, Demand & Price Updates
+- `change_supply()` and `change_demand()` automatically call `update_prices()`.
+- Price updates emit signals (`price_updated`, `supply_demand_updated`) so UI and events can react instantly.
+
+### Player Agency
+- `player_influence_event()` lets player actions manipulate markets—corner a resource, sabotage supply, or flood merchants with goods.
+- Background transactions simulate shipments, embargoes, and other world events.
+
+```gdscript title="Add a shipment"
+EconomyManager.add_transaction("Iron", 50, "shipment", delay=15.0)
+```
+
+### Background Processing
+- Queue events with `add_transaction()` and resolve them via `process_transactions(delta)` in the main loop.
+- Invoke `random_event()` periodically to keep markets unpredictable.
+
+```gdscript
+func _process(delta):
+    EconomyManager.process_transactions(delta)
+```
+
+### Debugging & Analytics
+- `debug_economy()` prints the current state.
+- `record_price_history()` tracks trends for dashboards or merchant UIs.
+
+### Integration Points
+
+- **Merchants** fetch prices with `get_price()` and update UI when signals fire.
+- **Quests** can spike demand or reduce supply for targeted items.
+- **EventManager** injects global events such as wars or festivals.
+- **FactionManager** personalizes pricing based on reputation.
+- **Crafting & Stashes** use current prices to evaluate profitability.
+
+### Gameplay Implications
+
+1. **Dynamic Economy** — Markets react to systemic and player-driven changes.
+2. **Player Exploitation** — Players can manipulate supply chains for profit or chaos.
+3. **Interactive World** — Shipments, embargoes, and faction moves shape the market.
+4. **Meaningful Decisions** — Choose between short-term gains or long-term stability.

--- a/docs/cobblestone/systems/personality-relationships.md
+++ b/docs/cobblestone/systems/personality-relationships.md
@@ -1,0 +1,33 @@
+---
+id: personality-relationships
+slug: /cobblestone/systems/personality-relationships
+title: Personality, Relationships & Dialog
+sidebar_label: Personality & Relationships
+---
+
+## Personality-Driven NPCs
+
+- Every NPC is generated with a unique Big Five personality profile that governs openness, agreeableness, extraversion, conscientiousness, and neuroticism.
+- Personalities influence trust, affinity growth, decision making, and even greeting style.
+- No two characters behave the same, ensuring emergent, memorable interactions.
+
+## Relationship Manager
+
+- Tracks affinity and trust for every player–NPC connection and NPC–NPC pairing.
+- Relationships grow organically through repeated positive encounters or decay when neglected.
+- Trait compatibility modifies relationship gains, making some bonds effortless and others fraught.
+- Rumors and shared history color how NPCs perceive the player before the next conversation even begins.
+
+## Dialog Integration
+
+- Greetings, prompts, and branching options adapt to affinity, trust, and personality data.
+- Conversations can recruit allies, unlock quests, resolve conflicts, or escalate rivalries.
+- Player-driven persona choices feed back into how the world responds, allowing roleplay to matter mechanically.
+
+## Role-Playing Potential
+
+- Define your own personality through actions, shaping how NPCs approach you.
+- Use social systems for diplomacy, espionage, performance, or manipulation.
+- Experience emergent storylines as personalities clash, align, or slowly evolve together.
+
+**Experience the depth of human interaction—reimagined.**

--- a/docs/cobblestone/systems/professions.md
+++ b/docs/cobblestone/systems/professions.md
@@ -1,0 +1,77 @@
+---
+id: professions
+slug: /cobblestone/systems/professions
+title: Professions & Trades
+sidebar_label: Professions & Trades
+---
+
+## Crafting Professions
+
+- Blacksmithing, Alchemy, Tailoring (implemented)
+- Carpentry — Build tools, structures, and furniture.
+- Tinkering — Craft gadgets, traps, and mechanical curios.
+- Cooking & Baking — Prepare food for buffs, trade, or survival.
+- Jewelry Crafting — Create rings, necklaces, and charms with social impact.
+
+## Resource Gathering
+
+- Fishing, Hunting, Mining, Farming (implemented)
+- Herbalism — Collect medicinal plants and rare alchemical reagents.
+- Lumberjacking — Harvest timber for carpentry, construction, or trade.
+- Scavenging — Search ruins and alleys for salvageable materials.
+
+## Trade & Commerce
+
+- Merchant — Optimize pricing, inventory, and storefront presentation.
+- Bartering — Specialize in item-for-item negotiation.
+- Innkeeper & Barkeep — Provide shelter, food, and faction gossip.
+- Banking — Manage wealth, vaults, and high-stakes loans.
+- Smuggling — Transport contraband while dodging guards and rival gangs.
+
+## Combat & Security
+
+- Weapon Mastery — Specialize in weapon families for unique moves.
+- Guarding — Earn coin as a hired protector or city guard.
+- Bounty Hunting — Track and capture wanted figures.
+- Assassination — Execute high-risk, stealth-oriented contracts.
+- Beast Taming — Command animals for combat or utility roles.
+
+## Social & Support Roles
+
+- Diplomacy (implemented) — Broker peace or escalate tensions.
+- Storytelling — Influence morale or earn coin via performance.
+- Healing — Provide medical aid, triage, or spiritual comfort.
+- Teaching — Train NPCs or apprentices to spread skill trees.
+- Espionage — Gather intelligence, infiltrate factions, or forge identities.
+- Performing Arts — Music, dance, and theatre for prestige or distraction.
+
+## Mystical Pursuits
+
+- Runecrafting — Inscribe magical effects onto gear or architecture.
+- Enchanting — Imbue items with lasting mystical bonuses.
+- Divination — Foretell events, locate caches, and read omens.
+- Necromancy — Command spirits or raise the dead with moral consequences.
+- Herbal Alchemy — Fuse botany and magic for hybrid concoctions.
+
+## City-Specific Work
+
+- Chimney Sweep — Keep industry humming and uncover rooftop secrets.
+- Rat Catcher — Manage urban vermin and plague risks.
+- Street Performer — Busk for tips and gather rumors.
+- Courier — Deliver packages across dangerous districts.
+- Locksmith — Craft, pick, and secure locks throughout the city.
+
+## Underground Opportunities
+
+- Thieving — Pickpocket, burgle, and heist your way to fortune.
+- Counterfeiting — Forge currency and documents.
+- Fence — Launder stolen goods for profit.
+- Gang Leader — Command crews, territory, and protection rackets.
+- Poisoner — Brew toxins for stealthy eliminations.
+
+## Exploration & Navigation
+
+- Cartography — Map the procedural city for resale or planning.
+- Pathfinding — Escort caravans or travelers through hazards.
+- Exploration — Discover secrets, ruins, or hidden districts.
+- Sailing & Shipwright — Maintain the harbor fleet and coastal ventures.

--- a/docs/cobblestone/world/_category_.json
+++ b/docs/cobblestone/world/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "World",
+  "position": 3,
+  "collapsed": false
+}

--- a/docs/cobblestone/world/city-map.md
+++ b/docs/cobblestone/world/city-map.md
@@ -1,0 +1,52 @@
+---
+id: city-map
+slug: /cobblestone/world/city-map
+title: City Map Brief
+sidebar_label: City Map
+---
+
+## Coastal Layout
+
+- Winding shoreline with sandy beaches, rocky cliffs, and a bustling harbor.
+- Islands and outcroppings dot the bay; a lighthouse crowns a storm-battered cliff.
+
+## District Breakdown
+
+### Slums
+Tight, chaotic alleys filled with shanties, hideouts, and covert meeting spots.
+
+### Market District
+An open-air bazaar of stalls, guild halls, and bustling foot traffic.
+
+### Industrial Zone
+Factories, warehouses, and smoke stacks belching across the skyline.
+
+### Residential & Noble Quarters
+Packed townhomes, manicured estates, gardens, and private guards.
+
+### Docks
+Shipyards, taverns, cranes, and storehouses lining the harbor.
+
+## Points of Interest
+
+- Central church with towering spires and a shadowed graveyard.
+- Guardhouse anchoring the city gate and chokepoints.
+- Gang hideouts hidden in factories and tunnels.
+- Dilapidated orphanage deep in the slums.
+- Merchant Guild Hall watching over the market.
+- Library or Scholar’s Hall tucked inside the noble quarter.
+- Signature taverns that act as social and quest hubs.
+- Sewer access points, hidden stashes, and secret routes.
+
+## Routes & Terrain
+
+- Cobblestone main streets connect districts; dirt paths thread the outskirts.
+- Forested hills, farmland, and a river frame the city.
+- Windmills turn along the ridge beyond the walls.
+- Harbor scenes feature moored ships, skiffs, and ferries.
+
+## Style Notes
+
+- Hand-drawn map with parchment tones, decorative borders, and illustrated icons.
+- Labels use thematic typography with icons (cross for church, anchor for harbor, etc.).
+- Include a compass rose, sea monsters, and sailing ships to reinforce the era.

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -1,4 +1,105 @@
 {
+  "dynamic-health": {
+    "title": "Dynamic Health & Vitality",
+    "subtitle": "Bodies that react to every decision",
+    "stage": 2,
+    "percent": 55,
+    "owner": "Denis Doiron",
+    "updatedAt": "2025-09-21",
+    "tags": ["Systems", "Survival"],
+    "summary": "Layered vitals simulation covering energy, hydration, body composition, and aging.",
+    "links": [
+      { "label": "Design Doc", "href": "/docs/cobblestone/systems/dynamic-health-vitality" }
+    ],
+    "timeline": [
+      { "date": "2025-09-01", "title": "Metabolic model prototype", "body": "Hooked calories & hydration into vitals pipeline." },
+      { "date": "2025-09-19", "title": "Body composition tuning", "body": "Added weight, fat, and muscle adaptation rules." }
+    ]
+  },
+  "dynamic-dialog": {
+    "title": "Dynamic Dialog System",
+    "subtitle": "Memory, mood, and faction-aware conversations",
+    "stage": 3,
+    "percent": 68,
+    "owner": "Denis Doiron",
+    "updatedAt": "2025-09-20",
+    "tags": ["Narrative", "AI"],
+    "summary": "Contextual dialogue with reputation, personality, and rumor hooks.",
+    "links": [
+      { "label": "Design Doc", "href": "/docs/cobblestone/systems/dynamic-dialog" }
+    ],
+    "timeline": [
+      { "date": "2025-09-07", "title": "Conversation state machine", "body": "Established JSON schema & runtime evaluator." },
+      { "date": "2025-09-16", "title": "Reputation gates", "body": "Integrated faction reputation and personality moodlets." }
+    ]
+  },
+  "rumor-system": {
+    "title": "Dynamic Rumor System",
+    "subtitle": "Propagation, decay, misinformation",
+    "stage": 3,
+    "percent": 70,
+    "owner": "Denis Doiron",
+    "updatedAt": "2025-09-21",
+    "tags": ["AI", "Systems"],
+    "summary": "Rumor graph with weighted spread, schedules, accuracy decay, and investigation tools.",
+    "links": [
+      { "label": "Design Doc", "href": "/docs/cobblestone/systems/dynamic-rumors" }
+    ],
+    "timeline": [
+      { "date": "2025-09-05", "title": "Propagation model", "body": "Edge weights by relationship & trait." },
+      { "date": "2025-09-15", "title": "Accuracy decay", "body": "Added rumor journal, accuracy scores, and spread history." }
+    ]
+  },
+  "personality-relationships": {
+    "title": "Personality & Relationships",
+    "subtitle": "Big Five traits inform every bond",
+    "stage": 2,
+    "percent": 50,
+    "owner": "Denis Doiron",
+    "updatedAt": "2025-09-18",
+    "tags": ["AI", "Narrative"],
+    "summary": "Personality-driven greetings, affinity, trust, and dialog routing.",
+    "links": [
+      { "label": "Design Doc", "href": "/docs/cobblestone/systems/personality-relationships" }
+    ],
+    "timeline": [
+      { "date": "2025-09-04", "title": "Trait generator", "body": "Rolled Big Five profiles for NPC templates." },
+      { "date": "2025-09-13", "title": "Relationship manager", "body": "Affinity & trust deltas feed dialog context." }
+    ]
+  },
+  "dynamic-quest-goals": {
+    "title": "Dynamic Quest & Goal System",
+    "subtitle": "Intent-driven quest webs",
+    "stage": 2,
+    "percent": 40,
+    "owner": "Denis Doiron",
+    "updatedAt": "2025-09-17",
+    "tags": ["Systems", "Narrative"],
+    "summary": "Player intents spawn adaptive questlines with dependency tracking.",
+    "links": [
+      { "label": "Design Doc", "href": "/docs/cobblestone/systems/dynamic-quest-goal-system" }
+    ],
+    "timeline": [
+      { "date": "2025-09-08", "title": "Intent scaffolding", "body": "Created goal templates and sub-quest generator." }
+    ]
+  },
+  "economy-manager": {
+    "title": "Economy Manager",
+    "subtitle": "Supply, demand, and player influence",
+    "stage": 2,
+    "percent": 45,
+    "owner": "Denis Doiron",
+    "updatedAt": "2025-09-19",
+    "tags": ["Systems", "Simulation"],
+    "summary": "Supply/demand engine with queued transactions and faction hooks.",
+    "links": [
+      { "label": "Technical Guide", "href": "/docs/cobblestone/systems/economy-manager" }
+    ],
+    "timeline": [
+      { "date": "2025-09-06", "title": "Transaction queue", "body": "Added delayed shipments and events." },
+      { "date": "2025-09-14", "title": "Player influence", "body": "Hooked merchant UI and faction price modifiers." }
+    ]
+  },
   "quest-system": {
     "title": "Quest System",
     "subtitle": "Objectives, states, rewards",
@@ -10,26 +111,12 @@
     "hero": "/img/features/quest-hero.png",
     "summary": "State machine for objectives; rewards/rep hooks; journal UI scaffolding.",
     "links": [
-      { "label": "Spec", "href": "/docs/systems/quests" },
+      { "label": "Design Doc", "href": "/docs/cobblestone/systems/dynamic-quest-goal-system" },
       { "label": "Design PR", "href": "https://github.com/EmergentRealms/..." }
     ],
     "timeline": [
       { "date": "2025-09-10", "title": "State machine skeleton", "body": "Created objective types & transitions." },
       { "date": "2025-09-18", "title": "Journal wireframe", "body": "Basic UI skeleton w/ filters." }
-    ]
-  },
-  "rumor-system": {
-    "title": "Rumor System",
-    "subtitle": "Propagation, decay, misinformation",
-    "stage": 3,
-    "percent": 65,
-    "owner": "Denis Doiron",
-    "updatedAt": "2025-09-19",
-    "tags": ["AI", "Systems"],
-    "summary": "Rumor graph with weighted spread, faction bias, and decay.",
-    "links": [{ "label": "Spec", "href": "/docs/systems/rumors" }],
-    "timeline": [
-      { "date": "2025-09-05", "title": "Propagation model", "body": "Edge weights by relationship & trait." }
     ]
   }
 }

--- a/src/pages/features/dynamic-dialog.tsx
+++ b/src/pages/features/dynamic-dialog.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import FeaturePage from '@site/src/components/FeaturePage/FeaturePage';
+
+export default function Page() {
+  return <FeaturePage id="dynamic-dialog" />;
+}

--- a/src/pages/features/dynamic-health.tsx
+++ b/src/pages/features/dynamic-health.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import FeaturePage from '@site/src/components/FeaturePage/FeaturePage';
+
+export default function Page() {
+  return <FeaturePage id="dynamic-health" />;
+}

--- a/src/pages/features/dynamic-quest-goals.tsx
+++ b/src/pages/features/dynamic-quest-goals.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import FeaturePage from '@site/src/components/FeaturePage/FeaturePage';
+
+export default function Page() {
+  return <FeaturePage id="dynamic-quest-goals" />;
+}

--- a/src/pages/features/economy-manager.tsx
+++ b/src/pages/features/economy-manager.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import FeaturePage from '@site/src/components/FeaturePage/FeaturePage';
+
+export default function Page() {
+  return <FeaturePage id="economy-manager" />;
+}

--- a/src/pages/features/personality-relationships.tsx
+++ b/src/pages/features/personality-relationships.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import FeaturePage from '@site/src/components/FeaturePage/FeaturePage';
+
+export default function Page() {
+  return <FeaturePage id="personality-relationships" />;
+}

--- a/src/pages/features/rumor-system.tsx
+++ b/src/pages/features/rumor-system.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import FeaturePage from '@site/src/components/FeaturePage/FeaturePage';
+
+export default function Page() {
+  return <FeaturePage id="rumor-system" />;
+}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -67,3 +67,92 @@
 .main {
   padding: 2rem 0 4rem;
 }
+
+.section {
+  margin: 0 auto;
+  padding: 3rem 0 0;
+  max-width: 1040px;
+}
+
+.sectionTitle {
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.sectionLead {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  max-width: 680px;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.featureGrid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.featureCard {
+  padding: 1.25rem;
+  border-radius: 16px;
+  border: 1px solid var(--ifm-border-color);
+  background: var(--ifm-background-surface-color);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.cardStage {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  border: 1px solid var(--ifm-border-color);
+  background: var(--ifm-background-color);
+  white-space: nowrap;
+}
+
+.cardFooter {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.ctaCard {
+  border: 1px solid var(--ifm-border-color);
+  border-radius: 18px;
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background:
+    radial-gradient(600px 400px at 15% 20%, rgba(201,164,107,0.18), transparent 60%),
+    var(--ifm-background-surface-color);
+}
+
+.ctaButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .ctaCard {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,37 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 
+import features from '@site/src/data/features.json';
+import FeatureProgress from '@site/src/components/FeatureProgress/FeatureProgress';
+
 import styles from './index.module.css';
+
+type Stage = 1 | 2 | 3 | 4 | 5;
+
+type FeatureCard = {
+  title: string;
+  stage: Stage;
+  summary?: string;
+  links?: {label: string; href: string}[];
+};
+
+const STAGE_LABEL: Record<Stage, string> = {
+  1: 'Not Started',
+  2: 'Ongoing',
+  3: 'In Testing',
+  4: 'Ready for QA',
+  5: 'Completed',
+};
+
+const FEATURE_SPOTLIGHT_IDS: string[] = [
+  'dynamic-health',
+  'dynamic-dialog',
+  'rumor-system',
+];
+
+const featureSpotlightEntries = FEATURE_SPOTLIGHT_IDS
+  .map((id) => [id, (features as Record<string, FeatureCard>)[id]] as const)
+  .filter((entry): entry is readonly [string, FeatureCard] => Boolean(entry[1]));
 
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
@@ -61,7 +91,63 @@ export default function Home(): ReactNode {
       description="Project hub for Emergent Realms: progress updates, roadmap, and technical docs.">
       <HomepageHeader />
       <main className={styles.main}>
-        {/* Optional: add your own sections or keep the default features component */}
+        <section className={styles.section}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Systems Spotlight
+          </Heading>
+          <p className={styles.sectionLead}>
+            Explore the latest pillars powering Grimborough. Each feature has living documentation and an interactive
+            status page for deeper dives.
+          </p>
+
+          <div className={styles.featureGrid}>
+            {featureSpotlightEntries.map(([id, feature]) => (
+              <div key={id} className={styles.featureCard}>
+                <div className={styles.cardHeader}>
+                  <Heading as="h3" className={styles.cardTitle}>
+                    {feature.title}
+                  </Heading>
+                  <span className={styles.cardStage}>{STAGE_LABEL[feature.stage]}</span>
+                </div>
+
+                <FeatureProgress title={feature.title} stage={feature.stage} size="sm" note={feature.summary} />
+
+                <div className={styles.cardFooter}>
+                  <Link className="button button--sm button--primary" to={`/features/${id}`}>
+                    View Status
+                  </Link>
+                  {!!feature.links?.length && (
+                    <Link className="button button--sm button--secondary" to={feature.links[0].href}>
+                      Read Docs
+                    </Link>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.ctaCard}>
+            <div>
+              <Heading as="h2" className={styles.sectionTitle}>
+                Need the bigger picture?
+              </Heading>
+              <p className={styles.sectionLead}>
+                Track milestones, metrics, and timelines on the dedicated status board, or jump straight into the expanded
+                Cobblestone Legacy documentation set.
+              </p>
+            </div>
+            <div className={styles.ctaButtons}>
+              <Link className="button button--primary button--lg" to="/status">
+                Open Status Board
+              </Link>
+              <Link className="button button--secondary button--lg" to="/docs/cobblestone/concept-framework">
+                Browse Documentation
+              </Link>
+            </div>
+          </div>
+        </section>
       </main>
     </Layout>
   );

--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import clsx from 'clsx';
+
+import features from '@site/src/data/features.json';
+import FeatureProgress from '@site/src/components/FeatureProgress/FeatureProgress';
+import KPIStat from '@site/src/components/KPIStat/KPIStat';
+import MilestoneCard from '@site/src/components/MilestoneCard/MilestoneCard';
+import Timeline from '@site/src/components/Timeline/Timeline';
+
+const STAGE_LABEL: Record<number, string> = {
+  1: 'Not Started',
+  2: 'Ongoing',
+  3: 'In Testing',
+  4: 'Ready for QA',
+  5: 'Completed',
+};
+
+type Feature = {
+  title: string;
+  stage: number;
+  percent?: number;
+  summary?: string;
+  links?: {label: string; href: string}[];
+};
+
+const featureEntries = Object.entries(features as Record<string, Feature>);
+const totalFeatures = featureEntries.length;
+const completedFeatures = featureEntries.filter(([, f]) => f.stage === 5).length;
+const activeFeatures = featureEntries.filter(([, f]) => f.stage > 1 && f.stage < 5).length;
+const docsPublished = 10; // New Cobblestone Legacy documentation pages added in this pass
+
+const milestones = [
+  {
+    title: 'Rumor Journal UI pass',
+    target: '2025-09-27',
+    stage: 3,
+    percent: 65,
+    note: 'Surface accuracy meter + spread history in the UI mock.',
+    links: [{label: 'Rumor System', href: '/features/rumor-system'}],
+  },
+  {
+    title: 'Dialog personality blending',
+    target: '2025-10-02',
+    stage: 2,
+    percent: 40,
+    note: 'Prototype mood-to-tone blending for greetings and quest pitches.',
+    links: [{label: 'Dynamic Dialog', href: '/features/dynamic-dialog'}],
+  },
+  {
+    title: 'Economy telemetry hooks',
+    target: '2025-09-29',
+    stage: 2,
+    percent: 45,
+    note: 'Expose price history graphs inside debug overlay.',
+    links: [{label: 'Economy Manager', href: '/features/economy-manager'}],
+  },
+] as const;
+
+const timelineItems = [
+  {
+    date: '2025-09-21',
+    title: 'Health & Vitality balancing pass',
+    body: 'Tuned body composition changes and starvation pacing based on first round of playtests.',
+    tag: 'Systems',
+  },
+  {
+    date: '2025-09-20',
+    title: 'Dialog reputation gates online',
+    body: 'Faction standing now unlocks bespoke quest pitches and rumour responses.',
+    tag: 'Narrative',
+  },
+  {
+    date: '2025-09-19',
+    title: 'Economy player influence hooks',
+    body: 'Merchants respond to hoarding, with transaction queues visible in the debugger.',
+    tag: 'Simulation',
+  },
+] as const;
+
+export default function StatusPage() {
+  return (
+    <Layout title="Project Status" description="Live project dashboard for Cobblestone Legacy.">
+      <header className="hero" style={{borderBottom: '1px solid var(--ifm-border-color)'}}>
+        <div className="container" style={{paddingTop: '3rem', paddingBottom: '2.5rem'}}>
+          <h1 className="hero__title" style={{marginBottom: '.5rem'}}>Cobblestone Legacy — Status Board</h1>
+          <p className="hero__subtitle" style={{maxWidth: 720}}>
+            Snapshot of feature progress, milestones, and recent updates. Jump into the docs for full breakdowns or track
+            individual features below.
+          </p>
+          <div style={{display: 'flex', flexWrap: 'wrap', gap: '0.75rem', marginTop: '1.5rem'}}>
+            <Link className="button button--primary button--lg" to="/docs/cobblestone/concept-framework">
+              Read Concept Framework
+            </Link>
+            <Link className="button button--secondary button--lg" to="/features">
+              Browse Feature Library
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="container" style={{paddingTop: '2.5rem', paddingBottom: '3rem'}}>
+        <section>
+          <h2 style={{marginBottom: '1rem'}}>Key Metrics</h2>
+          <div
+            style={{
+              display: 'grid',
+              gap: '1rem',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+            }}
+          >
+            <KPIStat label="Tracked Features" value={totalFeatures} hint="Across core systems" />
+            <KPIStat label="Active Workstreams" value={activeFeatures} hint="Stages 2–4" accent="warning" />
+            <KPIStat label="Systems Complete" value={`${completedFeatures}/${totalFeatures}`} hint="Stage 5" accent="success" />
+            <KPIStat label="Docs Published" value={docsPublished} hint="Cobblestone Legacy library" accent="neutral" />
+          </div>
+        </section>
+
+        <section style={{marginTop: '3rem'}}>
+          <div style={{display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1.5rem'}}>
+            <h2 style={{margin: 0}}>Feature Progress</h2>
+            <Link className="button button--sm button--link" to="/features">
+              View all features
+            </Link>
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gap: '1rem',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+            }}
+          >
+            {featureEntries.map(([id, feature]) => (
+              <div key={id} className="card" style={{padding: '1rem'}}>
+                <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.75rem'}}>
+                  <div>
+                    <h3 style={{marginBottom: '0.25rem'}}>{feature.title}</h3>
+                    <small style={{opacity: 0.8}}>{STAGE_LABEL[feature.stage]}</small>
+                  </div>
+                  <Link className="button button--sm button--secondary" to={`/features/${id}`}>
+                    Open
+                  </Link>
+                </div>
+
+                <FeatureProgress
+                  title={feature.title}
+                  stage={feature.stage as 1 | 2 | 3 | 4 | 5}
+                  size="sm"
+                  note={feature.summary}
+                />
+
+                {!!feature.links?.length && (
+                  <div style={{display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginTop: '0.75rem'}}>
+                    {feature.links.map((link) => (
+                      <Link key={link.href} className={clsx('button', 'button--sm', 'button--secondary')} to={link.href}>
+                        {link.label}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section style={{marginTop: '3rem'}}>
+          <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem'}}>
+            <h2 style={{margin: 0}}>Upcoming Milestones</h2>
+            <Link className="button button--sm button--link" to="/docs/roadmap">
+              View roadmap
+            </Link>
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gap: '1rem',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+              marginTop: '1.5rem',
+            }}
+          >
+            {milestones.map((milestone) => (
+              <MilestoneCard key={milestone.title} {...milestone} />
+            ))}
+          </div>
+        </section>
+
+        <section style={{marginTop: '3rem'}}>
+          <h2>Recent Updates</h2>
+          <Timeline items={timelineItems} />
+        </section>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add a structured Cobblestone Legacy documentation tree for concept, systems, narrative, and world details
- expand feature data, generate individual feature pages, and introduce a project status dashboard leveraging existing UI components
- refresh the homepage with a systems spotlight section linking to the new docs and status board

## Testing
- `npm run build -- --no-minify`


------
https://chatgpt.com/codex/tasks/task_b_68cff04631e48326a28d8488a7cf6d21