### PR TITLE
Add Godot DataViz UI Kit documentation

### DIFF
--- a/docs/toolkits/_category_.json
+++ b/docs/toolkits/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Toolkits & Assets",
+  "position": 50,
+  "link": {
+    "type": "generated-index",
+    "title": "Toolkits & Godot Assets"
+  }
+}

--- a/docs/toolkits/godot-dataviz/_category_.json
+++ b/docs/toolkits/godot-dataviz/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Godot DataViz UI Kit",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "title": "Godot DataViz UI Kit",
+    "description": "Production-ready charts, tables, tiles, and graph widgets for data-driven Godot games and tools."
+  }
+}

--- a/docs/toolkits/godot-dataviz/components/_category_.json
+++ b/docs/toolkits/godot-dataviz/components/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Components",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "title": "Godot DataViz Components",
+    "description": "Drill into each chart, tile, and widget included with the Godot DataViz UI Kit."
+  }
+}

--- a/docs/toolkits/godot-dataviz/components/bar-chart-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/bar-chart-view.mdx
@@ -1,0 +1,45 @@
+---
+id: bar-chart-view
+title: BarChartView
+sidebar_label: BarChartView
+description: Categorical data, crystal clear. Grouped and stacked bar charts with tooltips and palette control.
+---
+
+> **Tagline:** Categorical data, crystal clear.
+
+A fast, theme-aware bar chart for grouped or stacked series. Supports labels, tooltips, hover/click signals, and palette customization per series.
+
+## Data binding
+
+- `set_categories([...])`
+- `add_series(name: String, values: PackedFloat32Array)`
+- Optional stacked mode toggle and per-series color overrides.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — drop in your BarChartView capture here.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a BarChartView usage example.
+# Recommended: create a scene with a BarChartView node and feed categories + series.
+```
+
+## Why it's great
+
+- Switch between grouped or stacked layouts with a single flag.
+- Label rendering, tooltips, and hover/click signals baked in.
+- Palette-aware with global theme colors or per-series overrides.
+
+## Perfect for
+
+- Dashboards comparing factions, regions, or classes.
+- KPI boards with discrete categories.
+- Progress summaries where grouped/stacked views highlight change.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/box-plot-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/box-plot-view.mdx
@@ -1,0 +1,45 @@
+---
+id: box-plot-view
+title: BoxPlotView
+sidebar_label: BoxPlotView
+description: See distribution at a glance with box and whisker plots, outliers, and hover signals.
+---
+
+> **Tagline:** See distribution at a glance.
+
+Box & whisker plots with optional outliers—perfect for surfacing spreads in simulation output or balance reports. Supports both raw sample input and precomputed quartile stats.
+
+## Data binding
+
+- `set_groups([{ name, values }])` for raw sample arrays.
+- `add_box(min, q1, median, q3, max, outliers := PackedFloat32Array())` for prepared stats.
+- Toggle vertical or horizontal layout.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — replace with your BoxPlotView capture.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a BoxPlotView usage example.
+# Suggested: demonstrate raw group ingestion and optional outlier toggles.
+```
+
+## Why it's great
+
+- Automatic quartile computation for raw samples.
+- Optional outlier rendering and tooltips per element.
+- Hover/click interaction for boxes and whiskers.
+
+## Perfect for
+
+- Loot variability analysis.
+- NPC stat spreads across factions.
+- Combat or economy balance testing.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/detail-panel.mdx
+++ b/docs/toolkits/godot-dataviz/components/detail-panel.mdx
@@ -1,0 +1,45 @@
+---
+id: detail-panel
+title: DetailPanel
+sidebar_label: DetailPanel
+description: Readable facts instantly — labeled rows, grouped sections, and theme-aware layout.
+---
+
+> **Tagline:** Readable facts, instantly.
+
+A compact information sheet component with labeled rows, optional grouped sections, and automatic layout. Great for presenting selected entity details.
+
+## Data binding
+
+- `clear()` to reset content.
+- `add_group(title: String)` to start grouped sections (optional).
+- `add_row(label: String, value: Variant)` for each fact.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — add your DetailPanel capture.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a DetailPanel usage example.
+# Show grouped sections, row truncation, and tooltip usage.
+```
+
+## Why it's great
+
+- Automatic layout and label/value spacing.
+- Handles truncation with tooltips for long content.
+- Theme-aware typography and separators.
+
+## Perfect for
+
+- Selected actor/item/quest details.
+- Inspector sidebars or property sheets.
+- Narrative or codex entries with quick facts.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/entity-card.mdx
+++ b/docs/toolkits/godot-dataviz/components/entity-card.mdx
@@ -1,0 +1,46 @@
+---
+id: entity-card
+title: EntityCard
+sidebar_label: EntityCard
+description: Composable building block for nodes, panels, and lists with consistent styling.
+---
+
+> **Tagline:** Composable building block.
+
+A reusable card component that powers RelationshipGraphView nodes and any panel needing a title, lines, and optional icon.
+
+## Data binding
+
+- `set_title(text: String)`
+- `set_lines(lines: Array)`
+- `set_icon(texture: Texture2D)` (optional)
+- Enable dragging or drop targets as needed.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — add your EntityCard usage example.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide an EntityCard usage example.
+# Showcase title, lines, icons, and drag handles.
+```
+
+## Why it's great
+
+- Consistent look across graph nodes and list entries.
+- Theme-aware typography and spacing.
+- Drop-in component for dashboards or detail panels.
+
+## Perfect for
+
+- Relationship graphs and knowledge maps.
+- Sidebars, lists, or card-based menus.
+- Any place that needs a reusable summary card.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/filter-bar.mdx
+++ b/docs/toolkits/godot-dataviz/components/filter-bar.mdx
@@ -1,0 +1,46 @@
+---
+id: filter-bar
+title: FilterBar
+sidebar_label: FilterBar
+description: Filters without friction — buttons, toggles, menus, and inputs with normalized signals.
+---
+
+> **Tagline:** Filters without friction.
+
+A single-row action surface for buttons, toggles, menus, and search inputs. Emits a normalized `action(id, payload)` signal for easy handling.
+
+## Data binding
+
+- `add_button(id: String, label: String, icon := null)`
+- `add_toggle(id: String, label: String, initial := false)`
+- `add_menu(id: String, label: String, options: Array)`
+- `add_option`, `add_input`, `add_separator`, `add_spacer`
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — drop in your FilterBar layout.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a FilterBar usage example.
+# Wire up the action(id, payload) signal and showcase mixed controls.
+```
+
+## Why it's great
+
+- Consistent spacing and theme-aware styling.
+- Unified action signal regardless of control type.
+- Icon and tooltip support for rich toolstrips.
+
+## Perfect for
+
+- Search bars and data browsers.
+- Multi-facet filter panels.
+- Toolbar-style quick actions in editor tools.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/heat-map-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/heat-map-view.mdx
@@ -1,0 +1,45 @@
+---
+id: heat-map-view
+title: HeatMapView
+sidebar_label: HeatMapView
+description: Patterns pop instantly with labeled axes, palette legends, and hover states.
+---
+
+> **Tagline:** Patterns pop instantly.
+
+A grid heatmap with row/column labels, discrete or continuous palettes, and optional legend rendering. Designed for tactical overlays or management dashboards.
+
+## Data binding
+
+- `set_grid_size(rows: int, columns: int)`
+- `set_values(PackedFloat32Array)` in row-major order.
+- Optional label setters for rows, columns, and legends.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — capture your HeatMapView and drop it here.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a HeatMapView usage example.
+# Consider demonstrating palette swapping and legend support.
+```
+
+## Why it's great
+
+- Handles categorical or continuous data with palette presets.
+- Built-in legend and tooltip support for quick interpretation.
+- Hover/click signals for individual cells.
+
+## Perfect for
+
+- Pathfinding cost or influence maps.
+- Supply/demand overlays for economy sims.
+- AI affinity matrices or matchup grids.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/histogram-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/histogram-view.mdx
@@ -1,0 +1,45 @@
+---
+id: histogram-view
+title: HistogramView
+sidebar_label: HistogramView
+description: Bins done right with density fill, marker lines, and theme-aware styling.
+---
+
+> **Tagline:** Bins done right.
+
+A crisp histogram with optional mean or marker lines. Delivers fast binning, density fills, and gridline overlays to help interpret distributions at a glance.
+
+## Data binding
+
+- `set_samples(values: PackedFloat32Array)`
+- `set_bins(count: int)` or let the control auto-tune bins.
+- Optional marker or threshold lines.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — insert your HistogramView capture here.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a HistogramView usage example.
+# Tip: highlight how to set samples and configure marker lines.
+```
+
+## Why it's great
+
+- Fast binning on the fly for live data feeds.
+- Density fill, gridlines, and cursor readouts.
+- Fully theme-aware with hover/click feedback.
+
+## Perfect for
+
+- Damage distribution visualizations.
+- Runtime performance or metric monitoring.
+- Economy or loot simulation analysis.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/kpi-tile.mdx
+++ b/docs/toolkits/godot-dataviz/components/kpi-tile.mdx
@@ -1,0 +1,47 @@
+---
+id: kpi-tile
+title: KpiTile
+sidebar_label: KpiTile
+description: Headline metrics that sing with delta arrows, captions, and inline sparklines.
+---
+
+> **Tagline:** Headline metrics that sing.
+
+A hero KPI tile with big value, delta arrow, caption, and optional sparkline. Automatically color-codes up/down states and plays nicely with icons.
+
+## Data binding
+
+- `set_title(text: String)`
+- `set_value(value: Variant)`
+- `set_delta(delta_value: float)` with auto colorization.
+- `set_spark(values: PackedFloat32Array)`
+- `set_updated_ago(text: String)`
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — add your KpiTile showcase.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a KpiTile usage example.
+# Highlight title, value, delta arrow, and sparkline configuration.
+```
+
+## Why it's great
+
+- Instant readability for headline metrics.
+- Auto color palette for positive/negative deltas.
+- Optional icon slot and responsive typography.
+
+## Perfect for
+
+- Revenue, player count, or crime rate dashboards.
+- Faction power tracking or quest KPIs.
+- Any top-level metric that needs emphasis.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/line-chart-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/line-chart-view.mdx
@@ -1,0 +1,45 @@
+---
+id: line-chart-view
+title: LineChartView
+sidebar_label: LineChartView
+description: Your time-series workhorse with multi-series lines, fills, and hover signals.
+---
+
+> **Tagline:** Your time series workhorse.
+
+Multi-series line plotting with axes, gridlines, and optional area-under-line fill. Supports per-series colors, hover/click per point, and smooth rendering.
+
+## Data binding
+
+- `add_series(name: String, values: PackedFloat32Array)`
+- `set_x_labels(labels: PackedStringArray)` or inject custom axis formatters.
+- Optional smoothing, fill-under-line, and threshold markers.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — replace with a LineChartView shot.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a LineChartView usage example.
+# Showcase multiple series, custom colors, and hover callbacks.
+```
+
+## Why it's great
+
+- Smooth rendering even with dense time series.
+- Point and segment hover/click signals for interactive dashboards.
+- Area fill, markers, and custom tick formats to match your data.
+
+## Perfect for
+
+- Performance monitoring overlays.
+- Prices, health, or population trends over time.
+- Any time-based analytics in-game or in tools.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/relationship-graph-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/relationship-graph-view.mdx
@@ -1,0 +1,45 @@
+---
+id: relationship-graph-view
+title: RelationshipGraphView
+sidebar_label: RelationshipGraphView
+description: Clickable relationship maps with pan/zoom canvas, draggable cards, and arrowed links.
+---
+
+> **Tagline:** Clickable relationship maps.
+
+A pan/zoom canvas with draggable node cards and arrowed links. Includes simple layered auto-layout and emits hover/click signals for nodes and edges.
+
+## Data binding
+
+- `add_node(id: String, title: String, lines: Array, at := Vector2.ZERO)`
+- `add_edge(from_id: String, to_id: String, label := "")`
+- `layout()` to auto-position nodes when desired.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — add your RelationshipGraphView scene.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a RelationshipGraphView usage example.
+# Highlight node creation, edge wiring, and layout invocation.
+```
+
+## Why it's great
+
+- Drag-friendly cards with theme-aware EntityCard styling.
+- Zoom and pan across large graphs effortlessly.
+- Signals for hovering/clicking nodes and edges.
+
+## Perfect for
+
+- Quest flow or narrative relationship maps.
+- Transaction or document chain visualizations.
+- Faction ties and influence webs.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/sparkline-tile.mdx
+++ b/docs/toolkits/godot-dataviz/components/sparkline-tile.mdx
@@ -1,0 +1,44 @@
+---
+id: sparkline-tile
+title: SparklineTile
+sidebar_label: SparklineTile
+description: Tiny chart, big signal — minimalist inline plot for dense dashboards.
+---
+
+> **Tagline:** Tiny chart, big signal.
+
+A minimalist inline plot that fits anywhere. Optional fill and markers help you show trend direction without taking over your layout.
+
+## Data binding
+
+- `set_values(values: PackedFloat32Array)`
+- Toggle fill/marker visibility and baseline alignment.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — add your SparklineTile capture.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a SparklineTile usage example.
+# Demonstrate pairing with KPI tiles or list items.
+```
+
+## Why it's great
+
+- Zero chrome—just the data.
+- Works in cards, tables, or anywhere space is tight.
+- Optional markers highlight peaks or recent points.
+
+## Perfect for
+
+- Trend badges in dashboards.
+- Inline signals inside KPI tiles.
+- Compact overlays inside inventory or management UIs.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/timeline-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/timeline-view.mdx
@@ -1,0 +1,45 @@
+---
+id: timeline-view
+title: TimelineView
+sidebar_label: TimelineView
+description: Gantt-style clarity with tracks, events, tick scales, and live markers.
+---
+
+> **Tagline:** Gantt-style clarity.
+
+Track-based bars with configurable tick scales, auto label clipping, and an optional "now" marker. Great for schedules, incidents, or quest timelines.
+
+## Data binding
+
+- `set_tick_range(start: float, end: float)`
+- `add_track(name: String)`
+- `add_event(track: String, label: String, t0: float, t1: float, color := Color)`
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — insert your TimelineView capture.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a TimelineView usage example.
+# Demonstrate tracks, events, and the optional "now" marker.
+```
+
+## Why it's great
+
+- Hover/click signals on events.
+- Gridlines and label management keep timelines readable.
+- Works for absolute or relative time scales.
+
+## Perfect for
+
+- Incident or quest tracking.
+- Faction operations planning.
+- Simulation or production schedules.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/tool-bar.mdx
+++ b/docs/toolkits/godot-dataviz/components/tool-bar.mdx
@@ -1,0 +1,44 @@
+---
+id: tool-bar
+title: ToolBar
+sidebar_label: ToolBar
+description: Your command surface — Godot-native action strip with normalized signals and icon support.
+---
+
+> **Tagline:** Your command surface.
+
+A lightweight toolbar that matches Godot's look and hooks into the same builder API as FilterBar. Ideal for primary commands or view mode switches.
+
+## Data binding
+
+- `add_button`, `add_toggle`, `add_menu`, `add_option`, `add_input`, `add_separator`, `add_spacer`
+- Listen for the shared `action(id, payload)` signal.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — add your ToolBar configuration.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a ToolBar usage example.
+# Demonstrate button icons, toggles, and payload handling.
+```
+
+## Why it's great
+
+- Shares API and styling cues with FilterBar for consistency.
+- Icon, tooltip, and toggle states out of the box.
+- Lightweight footprint for editor or runtime UIs.
+
+## Perfect for
+
+- Top-level app controls.
+- View mode or layout toggles.
+- Command strips in tooling or overlays.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/virtual-table-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/virtual-table-view.mdx
@@ -1,0 +1,45 @@
+---
+id: virtual-table-view
+title: VirtualTableView
+sidebar_label: VirtualTableView
+description: Huge datasets, still smooth — virtualized, read-only grid with precise hit testing.
+---
+
+> **Tagline:** Huge datasets, still smooth.
+
+A virtualized table that renders only what is visible. Features striped rows, header controls, and precise cell hit-testing for responsive interactions.
+
+## Data binding
+
+- `set_columns(columns: Array)`
+- `set_row_count(count: int)`
+- `set_cell_cb(func(row: int, column: int) -> Variant)` for lazy data fetch.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — add your VirtualTableView capture.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a VirtualTableView usage example.
+# Illustrate column definitions and callback-driven cell data.
+```
+
+## Why it's great
+
+- Handles millions of rows without choking.
+- Header row, striped styling, and selection support.
+- Fine-grained hover/click signals per cell.
+
+## Perfect for
+
+- Log viewers and telemetry dashboards.
+- Inventory or database browsers.
+- Any read-only dataset where performance matters.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/components/waterfall-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/waterfall-view.mdx
@@ -1,0 +1,44 @@
+---
+id: waterfall-view
+title: WaterfallView
+sidebar_label: WaterfallView
+description: How you got from A → B — cumulative plus/minus steps with color-coded totals.
+---
+
+> **Tagline:** How you got from A → B.
+
+Visualize cumulative deltas leading to a final total. Automatically computes running sums, color-codes ups/downs, and labels every step.
+
+## Data binding
+
+- `set_steps(steps: Array)` where each step is `{ label, delta }`
+- `set_base_value(value: float)` for the starting total.
+
+## Screenshot
+
+<figure>
+  <p><em>Screenshot placeholder — add your WaterfallView example.</em></p>
+</figure>
+
+## Example usage
+
+```gdscript
+# TODO: Provide a WaterfallView usage example.
+# Demonstrate positive/negative deltas and total highlighting.
+```
+
+## Why it's great
+
+- Automatic running total calculation and labeling.
+- Color coding for increases, decreases, and totals.
+- Ideal for showing contributions to a final outcome.
+
+## Perfect for
+
+- Economy delta breakdowns.
+- Budget or scoring recaps.
+- Post-mortem analyses in tools or dashboards.
+
+---
+
+[← Back to kit overview](../..)

--- a/docs/toolkits/godot-dataviz/index.mdx
+++ b/docs/toolkits/godot-dataviz/index.mdx
@@ -1,0 +1,83 @@
+---
+id: godot-dataviz-ui-kit
+slug: /toolkits/godot-dataviz-ui-kit
+title: Godot DataViz UI Kit
+sidebar_label: Overview
+description: Production-ready charts, tables, tiles, and graph widgets for data-driven Godot games and tools.
+---
+
+import KPIStat from '@site/src/components/KPIStat/KPIStat';
+
+> **Tagline:** Production-ready charts, tables, tiles, and graph widgets for data-driven Godot games and tools.
+
+A reusable UI toolkit for Godot 4 that ships with polished, data-agnostic controls: BarChartView, LineChartView, HistogramView, SparklineTile, KpiTile, HeatMapView, BoxPlotView, TimelineView, VirtualTableView, FilterBar, ToolBar, DetailPanel, WaterfallView, RelationshipGraphView, and helper EntityCard nodes. Every control is theme-aware, emits hover/click signals, and plays nicely with both GDScript and C++.
+
+<section className="margin-top--md margin-bottom--lg" style={{display:'flex', flexWrap:'wrap', gap:'var(--ifm-spacing-horizontal)'}}>
+  <KPIStat label="Controls Included" value={"14+"} hint="Charts, tiles, panels" accent="success" />
+  <KPIStat label="Godot Version" value="4.x" hint="GDScript + C++" accent="primary" />
+  <KPIStat label="APIs" value="Data-agnostic" hint="Arrays, callables, variants" accent="neutral" />
+  <KPIStat label="Platforms" value="Windows / macOS / Linux" accent="warning" />
+</section>
+
+## Why ship this kit?
+
+- **Build dashboards fast.** Drop in polished widgets for analytics overlays, live operations dashboards, and tooling.
+- **Stay decoupled.** Feed controls with arrays, callables, or lightweight adapters—no database bindings required.
+- **Delight the eye.** Theme colors, typography, tooltips, and selection states match your project's look.
+- **Ship confidently.** Hover/click signals, zoom/pan, legend + labels, and virtualization features are ready for production.
+
+## What's inside
+
+The kit includes the following controls and helpers. Jump into the component docs for screenshots, data binding tips, and code snippets.
+
+| Component | Snapshot | Perfect for |
+| --- | --- | --- |
+| [BarChartView](./components/bar-chart-view) | Grouped or stacked bar charts with labels, tooltips, and palette controls. | Dashboards, comparisons, KPIs across factions or regions. |
+| [BoxPlotView](./components/box-plot-view) | Box & whisker plots with optional outliers and auto quartiles. | Simulation outputs, loot variability, balance testing. |
+| [HistogramView](./components/histogram-view) | Fast binning, density fills, and marker lines. | Damage distributions, runtime metrics, economy simulations. |
+| [HeatMapView](./components/heat-map-view) | Grid heatmaps with categorical axes and palette legends. | Pathfinding costs, supply & demand, AI affinity matrices. |
+| [LineChartView](./components/line-chart-view) | Multi-series time-series plotting with hover and segment selection. | Performance metrics, price history, health over time. |
+| [SparklineTile](./components/sparkline-tile) | Minimal sparkline for dense dashboards. | Trend badges, KPI cards, inline deltas. |
+| [KpiTile](./components/kpi-tile) | Headline metric tile with delta arrow and sparkline. | Revenue, player count, faction power. |
+| [DetailPanel](./components/detail-panel) | Labeled rows and grouped sections for quick facts. | Selected actor/item/quest overviews. |
+| [FilterBar](./components/filter-bar) | One-row action strip with normalized action signals. | Search bars, data browsers, multi-facet filters. |
+| [ToolBar](./components/tool-bar) | Godot-native action strip for primary commands. | Top-level app controls, view mode switches. |
+| [TimelineView](./components/timeline-view) | Gantt-style timeline with tracks, events, and "now" marker. | Incident timelines, quests, operations scheduling. |
+| [VirtualTableView](./components/virtual-table-view) | Virtualized grid for massive datasets. | Logs, inventories, metrics, large tables. |
+| [RelationshipGraphView](./components/relationship-graph-view) | Pan/zoom node graph with draggable cards and edges. | Quest flows, transaction graphs, faction ties. |
+| [WaterfallView](./components/waterfall-view) | Cumulative step visualization from start to finish. | Economy deltas, budgets, scoring breakdowns. |
+| [EntityCard](./components/entity-card) | Reusable card element for nodes or panels. | Graph nodes, sidebars, list entries. |
+
+## Common features
+
+- **Data-agnostic APIs:** Push arrays, Packed* data, or callables; no persistence assumptions.
+- **Signals everywhere:** Hover, click, selection, and action signals for interactive experiences.
+- **Theme aware:** Looks great out of the box; fully customizable colors and fonts.
+- **Performance first:** CanvasItem drawing, internal buffering, virtualized lists, and optimized layouts.
+- **Editor & code friendly:** Use as scene nodes or construct programmatically.
+
+## Compatibility & packaging
+
+- **Engine:** Godot 4.x (GDExtension, C++)
+- **Platforms:** Windows, macOS, Linux
+- **Examples:** GDScript demo scenes per control
+- **Docs:** Quickstart + API snippets for each control
+- **License:** MIT (bundle your own fonts/icons)
+
+## Store & SEO quick hits
+
+- **Search title:** Godot 4 Charts & Data UI (DataViz UI Kit)
+- **Slug suggestion:** `godot-dataviz-ui-kit`
+- **Tags/Keywords:** godot, godot4, ui, toolkit, charts, chart, graph, data, dataviz, visualization, dashboard, table, grid, heatmap, histogram, sparkline, kpi, timeline, waterfall, boxplot, line chart, bar chart, relationship graph, node graph, editor plugin, runtime ui, gdextension, gdscript, c++
+- **Alt keywords:** game analytics ui, dashboard ui, node graph ui, table view, plot widgets
+
+## Promo bullet ideas
+
+- Plug-and-play controls • Data-agnostic APIs
+- Beautiful defaults • Theme & font friendly
+- Hover/Click signals • Tooltips • Selection
+- Zoom/Pan (where relevant)
+- Works with GDScript & C++ (GDExtension)
+- Great for RPG sims, economy dashboards, dev tools
+
+Ready to dive deeper? Explore the component pages in this section or grab the kit on itch.io when it launches.

--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -7,7 +7,9 @@ import features from '@site/src/data/features.json';
 import FeatureProgress from '@site/src/components/FeatureProgress/FeatureProgress';
 import KPIStat from '@site/src/components/KPIStat/KPIStat';
 import MilestoneCard from '@site/src/components/MilestoneCard/MilestoneCard';
+import type {MilestoneCardProps} from '@site/src/components/MilestoneCard/MilestoneCard';
 import Timeline from '@site/src/components/Timeline/Timeline';
+import type {TimelineItem} from '@site/src/components/Timeline/Timeline';
 
 const STAGE_LABEL: Record<number, string> = {
   1: 'Not Started',
@@ -31,7 +33,7 @@ const completedFeatures = featureEntries.filter(([, f]) => f.stage === 5).length
 const activeFeatures = featureEntries.filter(([, f]) => f.stage > 1 && f.stage < 5).length;
 const docsPublished = 10; // New Cobblestone Legacy documentation pages added in this pass
 
-const milestones = [
+const milestones: MilestoneCardProps[] = [
   {
     title: 'Rumor Journal UI pass',
     target: '2025-09-27',
@@ -56,9 +58,9 @@ const milestones = [
     note: 'Expose price history graphs inside debug overlay.',
     links: [{label: 'Economy Manager', href: '/features/economy-manager'}],
   },
-] as const;
+];
 
-const timelineItems = [
+const timelineItems: TimelineItem[] = [
   {
     date: '2025-09-21',
     title: 'Health & Vitality balancing pass',
@@ -77,7 +79,7 @@ const timelineItems = [
     body: 'Merchants respond to hoarding, with transaction queues visible in the debugger.',
     tag: 'Simulation',
   },
-] as const;
+];
 
 export default function StatusPage() {
   return (


### PR DESCRIPTION
## Summary
- add a Toolkits & Assets documentation section with a Godot DataViz UI Kit overview page
- document each kit component with data binding notes, screenshot placeholders, and example code stubs
- fix status page milestone and timeline typing so the docs build passes type checking

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68d34447d2c0832689f859172e02afca