### PR TITLE
Refresh homepage branding and docs navigation

### DIFF
--- a/docs/cobblestone/overview.md
+++ b/docs/cobblestone/overview.md
@@ -1,7 +1,8 @@
 ---
-id: overview
+id: cobblestone-overview
 title: Project Overview
-sidebar_position: 3
+sidebar_position: 0
+slug: /cobblestone/overview
 ---
 
 # Cobblestone Legacy

--- a/docs/toolkits/_category_.json
+++ b/docs/toolkits/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Toolkits & Assets",
-  "position": 50,
+  "position": 3,
   "link": {
     "type": "generated-index",
     "title": "Toolkits & Godot Assets"

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,8 +3,8 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
-  title: 'Emergent Realms Inc.',
-  tagline: 'Devlog & docs for Emergent Realms',
+  title: 'Emergent Realms',
+  tagline: 'Worlds forged of chaos.',
   favicon: 'img/favicon.ico',
 
   future: { v4: true },
@@ -48,10 +48,10 @@ const config: Config = {
     colorMode: { defaultMode: 'dark', respectPrefersColorScheme: true },
     image: 'img/ChatterdRealms.png',
     navbar: {
-      title: 'Cobblestone Legacy',
-      logo: { alt: 'Cobblestone Legacy', src: 'img/logo.pgn', srcDark: 'img/logo-dark.svg'},
+      title: 'Emergent Realms',
+      logo: { alt: 'Emergent Realms', src: 'img/logo.pgn', srcDark: 'img/logo-dark.svg'},
       items: [
-        { to: '/docs/overview', label: 'Docs', position: 'left' },
+        { to: '/docs/cobblestone/overview', label: 'Docs', position: 'left' },
         { to: '/blog', label: 'Devlog', position: 'left' },
         { to: '/features', label: 'Features', position: 'left' },
         { href: 'https://discord.gg/23MyDvkW', label: 'Join Discord', position: 'right' },
@@ -62,7 +62,7 @@ const config: Config = {
     footer: {
       style: 'dark',
       links: [
-        { title: 'Docs', items: [{ label: 'Overview', to: '/docs/overview' }] },
+        { title: 'Docs', items: [{ label: 'Overview', to: '/docs/cobblestone/overview' }] },
         { title: 'Community', items: [{ label: 'Discord', href: 'https://discord.gg/23MyDvkW' }] },
         { title: 'More', items: [{ label: 'Devlog', to: '/blog' }] },
         

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -4,10 +4,9 @@
   position: relative;
   overflow: hidden;
   border-bottom: 1px solid var(--ifm-border-color);
-  /* subtle brass glow gradients, no images */
   background:
-    radial-gradient(1200px 500px at 20% -10%, rgba(201,164,107,0.20), transparent 60%),
-    radial-gradient(800px 400px at 80% 0%, rgba(201,164,107,0.12), transparent 60%),
+    radial-gradient(1200px 500px at 20% -10%, rgba(201, 164, 107, 0.2), transparent 60%),
+    radial-gradient(800px 400px at 80% 0%, rgba(201, 164, 107, 0.12), transparent 60%),
     transparent;
 }
 
@@ -20,6 +19,13 @@
   margin-top: 0.75rem;
 }
 
+.heroLead {
+  margin: 1.25rem auto 0;
+  max-width: 760px;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 1.05rem;
+}
+
 .buttons {
   margin-top: 2rem;
   display: flex;
@@ -28,39 +34,31 @@
   flex-wrap: wrap;
 }
 
-/* third “ghost” button */
-.ghost {
-  background: transparent;
-  border: 1px solid var(--ifm-border-color);
-  color: var(--ifm-color-emphasis-200);
-}
-.ghost:hover { color: var(--ifm-color-emphasis-100); }
-
-/* Discord CTA — brand colors with accessible contrast */
 .discord {
-  background: #5865F2;             /* Discord blurple */
+  background: #5865f2;
   color: #fff;
   border: 1px solid transparent;
-  box-shadow: 0 1px 0 rgba(0,0,0,0.2);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
 }
 
 .discord:hover,
 .discord:focus-visible {
-  background: #4752C4;             /* hover */
+  background: #4752c4;
   color: #fff;
   text-decoration: none;
 }
 
 .discord:active {
-  background: #3c45a5;             /* active */
+  background: #3c45a5;
 }
 
 .discord,
 .button--primary,
-.button--secondary { border-radius: 10px; }
+.button--secondary {
+  border-radius: 10px;
+}
 
 [data-theme='light'] .discord {
-  /* Keep it vibrant on light backgrounds too */
   border-color: #4c57d8;
 }
 
@@ -71,88 +69,42 @@
 .section {
   margin: 0 auto;
   padding: 3rem 0 0;
-  max-width: 1040px;
+  max-width: 880px;
 }
 
 .sectionTitle {
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
   letter-spacing: 0.01em;
 }
 
 .sectionLead {
   margin-top: 0;
-  margin-bottom: 2rem;
+  margin-bottom: 0;
   max-width: 680px;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 1.05rem;
+}
+
+.copyList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.5rem;
+  font-size: 1.05rem;
   color: var(--ifm-color-emphasis-700);
 }
 
-.featureGrid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+.copyList strong {
+  color: var(--ifm-color-emphasis-900);
 }
 
-.featureCard {
-  padding: 1.25rem;
-  border-radius: 16px;
-  border: 1px solid var(--ifm-border-color);
-  background: var(--ifm-background-surface-color);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.cardHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-.cardTitle {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.cardStage {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  border: 1px solid var(--ifm-border-color);
-  background: var(--ifm-background-color);
-  white-space: nowrap;
-}
-
-.cardFooter {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.ctaCard {
-  border: 1px solid var(--ifm-border-color);
-  border-radius: 18px;
-  padding: 2.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  background:
-    radial-gradient(600px 400px at 15% 20%, rgba(201,164,107,0.18), transparent 60%),
-    var(--ifm-background-surface-color);
-}
-
-.ctaButtons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
+.exploreList {
+  gap: 1.25rem;
 }
 
 @media (min-width: 768px) {
-  .ctaCard {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+  .section {
+    max-width: 960px;
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,59 +1,30 @@
 import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 
-import features from '@site/src/data/features.json';
-import FeatureProgress from '@site/src/components/FeatureProgress/FeatureProgress';
-
 import styles from './index.module.css';
 
-type Stage = 1 | 2 | 3 | 4 | 5;
-
-type FeatureCard = {
-  title: string;
-  stage: Stage;
-  summary?: string;
-  links?: {label: string; href: string}[];
-};
-
-const STAGE_LABEL: Record<Stage, string> = {
-  1: 'Not Started',
-  2: 'Ongoing',
-  3: 'In Testing',
-  4: 'Ready for QA',
-  5: 'Completed',
-};
-
-const FEATURE_SPOTLIGHT_IDS: string[] = [
-  'dynamic-health',
-  'dynamic-dialog',
-  'rumor-system',
-];
-
-const featureSpotlightEntries = FEATURE_SPOTLIGHT_IDS
-  .map((id) => [id, (features as Record<string, FeatureCard>)[id]] as const)
-  .filter((entry): entry is readonly [string, FeatureCard] => Boolean(entry[1]));
-
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <header className={clsx('hero', styles.heroBanner)}>
       <div className="container">
         <Heading as="h1" className={clsx('hero__title', styles.title)}>
-          Cobblestone Legacy
+          Emergent Realms Inc.
         </Heading>
-        <p className={clsx('hero__subtitle', styles.subtitle)}>
-          Devlog, roadmap, and systems documentation for Emergent Realms.
+        <p className={clsx('hero__subtitle', styles.subtitle)}>Worlds forged of chaos.</p>
+        <p className={styles.heroLead}>
+          Emergent Realms is an indie studio building living, breathing game worlds where every choice echoes.
+          We’re the creators of Cobblestone Legacy—a sandbox RPG with rogue-lite survival, systemic factions,
+          and emergent storytelling—built on Godot with high-performance C++ GDExtensions.
         </p>
 
         <div className={styles.buttons}>
           <Link className="button button--primary button--lg" to="/blog">
             Read the Devlog
           </Link>
-          <Link className="button button--secondary button--lg" to="/docs/overview">
+          <Link className="button button--secondary button--lg" to="/docs/cobblestone/overview">
             View Docs
           </Link>
           <Link
@@ -63,7 +34,6 @@ function HomepageHeader() {
             rel="noopener noreferrer"
             aria-label="Join our Discord server"
           >
-            {/* Inline Discord icon for crisp rendering */}
             <svg
               aria-hidden="true"
               viewBox="0 0 24 24"
@@ -87,66 +57,67 @@ function HomepageHeader() {
 export default function Home(): ReactNode {
   return (
     <Layout
-      title="Cobblestone Legacy — Devlog & Docs"
-      description="Project hub for Emergent Realms: progress updates, roadmap, and technical docs.">
+      title="Emergent Realms — Worlds forged of chaos"
+      description="Emergent Realms builds living game worlds: follow the devlog, explore docs, and grab tools."
+    >
       <HomepageHeader />
       <main className={styles.main}>
         <section className={styles.section}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Systems Spotlight
+            What we do
           </Heading>
-          <p className={styles.sectionLead}>
-            Explore the latest pillars powering Grimborough. Each feature has living documentation and an interactive
-            status page for deeper dives.
-          </p>
-
-          <div className={styles.featureGrid}>
-            {featureSpotlightEntries.map(([id, feature]) => (
-              <div key={id} className={styles.featureCard}>
-                <div className={styles.cardHeader}>
-                  <Heading as="h3" className={styles.cardTitle}>
-                    {feature.title}
-                  </Heading>
-                  <span className={styles.cardStage}>{STAGE_LABEL[feature.stage]}</span>
-                </div>
-
-                <FeatureProgress title={feature.title} stage={feature.stage} size="sm" note={feature.summary} />
-
-                <div className={styles.cardFooter}>
-                  <Link className="button button--sm button--primary" to={`/features/${id}`}>
-                    View Status
-                  </Link>
-                  {!!feature.links?.length && (
-                    <Link className="button button--sm button--secondary" to={feature.links[0].href}>
-                      Read Docs
-                    </Link>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+          <ul className={styles.copyList}>
+            <li>
+              <strong>Make games that feel alive:</strong> AI-driven NPCs with memory, routines, and relationships;
+              procedural cities; dynamic economy and heist systems.
+            </li>
+            <li>
+              <strong>Share the journey:</strong> Devlogs, technical write-ups, and design docs that open our process to
+              players and fellow developers.
+            </li>
+            <li>
+              <strong>Build tools for developers:</strong> Production-ready Godot UI components, data-viz controls, and
+              high-throughput SQLite/GDExtension backends—designed for performance, clarity, and reuse.
+            </li>
+          </ul>
         </section>
 
         <section className={styles.section}>
-          <div className={styles.ctaCard}>
-            <div>
-              <Heading as="h2" className={styles.sectionTitle}>
-                Need the bigger picture?
-              </Heading>
-              <p className={styles.sectionLead}>
-                Track milestones, metrics, and timelines on the dedicated status board, or jump straight into the expanded
-                Cobblestone Legacy documentation set.
-              </p>
-            </div>
-            <div className={styles.ctaButtons}>
-              <Link className="button button--primary button--lg" to="/status">
-                Open Status Board
-              </Link>
-              <Link className="button button--secondary button--lg" to="/docs/cobblestone/concept-framework">
-                Browse Documentation
-              </Link>
-            </div>
-          </div>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Explore
+          </Heading>
+          <ul className={clsx(styles.copyList, styles.exploreList)}>
+            <li>
+              <strong>Devlogs &amp; Docs</strong> — Follow the build, from AI perception to world simulation.
+            </li>
+            <li>
+              <strong>Game Hub</strong> — Learn about Cobblestone Legacy’s survival loop, factions, and roadmap.
+            </li>
+            <li>
+              <strong>Toolkits &amp; Assets</strong> — Browse our Godot components and backend systems to accelerate your
+              project.
+            </li>
+          </ul>
+        </section>
+
+        <section className={styles.section}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            How we build
+          </Heading>
+          <p className={styles.sectionLead}>
+            Performance-minded. Multithreaded where it counts. Data-driven. We favor clean APIs, predictable behavior,
+            and thorough examples—so our worlds (and your projects) scale gracefully.
+          </p>
+        </section>
+
+        <section className={styles.section}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Join us
+          </Heading>
+          <p className={styles.sectionLead}>
+            Whether you’re here to play, to learn, or to ship faster: welcome to the realm. Start with the latest devlog,
+            try a live demo (when available), or grab a toolkit and build with us.
+          </p>
         </section>
       </main>
     </Layout>


### PR DESCRIPTION
## Summary
- replace the landing page spotlight with studio-focused messaging and update the hero buttons
- move the Project Overview doc under Cobblestone Legacy and reorder the docs sidebar structure
- retitle the navbar brand to "Emergent Realms" and point global links to the new overview path

## Testing
- npm run build *(fails: existing broken doc links under docs/toolkits)*

------
https://chatgpt.com/codex/tasks/task_b_68d356194f8c8326990cb8c5d4b34ff8