### PR TITLE
Fix Godot DataViz doc links

### DIFF
--- a/docs/toolkits/godot-dataviz/components/bar-chart-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/bar-chart-view.mdx
@@ -42,4 +42,4 @@ A fast, theme-aware bar chart for grouped or stacked series. Supports labels, to
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/box-plot-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/box-plot-view.mdx
@@ -42,4 +42,4 @@ Box & whisker plots with optional outliers—perfect for surfacing spreads in si
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/detail-panel.mdx
+++ b/docs/toolkits/godot-dataviz/components/detail-panel.mdx
@@ -42,4 +42,4 @@ A compact information sheet component with labeled rows, optional grouped sectio
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/entity-card.mdx
+++ b/docs/toolkits/godot-dataviz/components/entity-card.mdx
@@ -43,4 +43,4 @@ A reusable card component that powers RelationshipGraphView nodes and any panel 
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/filter-bar.mdx
+++ b/docs/toolkits/godot-dataviz/components/filter-bar.mdx
@@ -43,4 +43,4 @@ A single-row action surface for buttons, toggles, menus, and search inputs. Emit
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/heat-map-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/heat-map-view.mdx
@@ -42,4 +42,4 @@ A grid heatmap with row/column labels, discrete or continuous palettes, and opti
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/histogram-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/histogram-view.mdx
@@ -42,4 +42,4 @@ A crisp histogram with optional mean or marker lines. Delivers fast binning, den
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/kpi-tile.mdx
+++ b/docs/toolkits/godot-dataviz/components/kpi-tile.mdx
@@ -44,4 +44,4 @@ A hero KPI tile with big value, delta arrow, caption, and optional sparkline. Au
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/line-chart-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/line-chart-view.mdx
@@ -42,4 +42,4 @@ Multi-series line plotting with axes, gridlines, and optional area-under-line fi
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/relationship-graph-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/relationship-graph-view.mdx
@@ -42,4 +42,4 @@ A pan/zoom canvas with draggable node cards and arrowed links. Includes simple l
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/sparkline-tile.mdx
+++ b/docs/toolkits/godot-dataviz/components/sparkline-tile.mdx
@@ -41,4 +41,4 @@ A minimalist inline plot that fits anywhere. Optional fill and markers help you 
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/timeline-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/timeline-view.mdx
@@ -42,4 +42,4 @@ Track-based bars with configurable tick scales, auto label clipping, and an opti
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/tool-bar.mdx
+++ b/docs/toolkits/godot-dataviz/components/tool-bar.mdx
@@ -41,4 +41,4 @@ A lightweight toolbar that matches Godot's look and hooks into the same builder 
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/virtual-table-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/virtual-table-view.mdx
@@ -42,4 +42,4 @@ A virtualized table that renders only what is visible. Features striped rows, he
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/components/waterfall-view.mdx
+++ b/docs/toolkits/godot-dataviz/components/waterfall-view.mdx
@@ -41,4 +41,4 @@ Visualize cumulative deltas leading to a final total. Automatically computes run
 
 ---
 
-[← Back to kit overview](../..)
+[← Back to kit overview](/docs/toolkits/godot-dataviz)

--- a/docs/toolkits/godot-dataviz/index.mdx
+++ b/docs/toolkits/godot-dataviz/index.mdx
@@ -32,21 +32,21 @@ The kit includes the following controls and helpers. Jump into the component doc
 
 | Component | Snapshot | Perfect for |
 | --- | --- | --- |
-| [BarChartView](./components/bar-chart-view) | Grouped or stacked bar charts with labels, tooltips, and palette controls. | Dashboards, comparisons, KPIs across factions or regions. |
-| [BoxPlotView](./components/box-plot-view) | Box & whisker plots with optional outliers and auto quartiles. | Simulation outputs, loot variability, balance testing. |
-| [HistogramView](./components/histogram-view) | Fast binning, density fills, and marker lines. | Damage distributions, runtime metrics, economy simulations. |
-| [HeatMapView](./components/heat-map-view) | Grid heatmaps with categorical axes and palette legends. | Pathfinding costs, supply & demand, AI affinity matrices. |
-| [LineChartView](./components/line-chart-view) | Multi-series time-series plotting with hover and segment selection. | Performance metrics, price history, health over time. |
-| [SparklineTile](./components/sparkline-tile) | Minimal sparkline for dense dashboards. | Trend badges, KPI cards, inline deltas. |
-| [KpiTile](./components/kpi-tile) | Headline metric tile with delta arrow and sparkline. | Revenue, player count, faction power. |
-| [DetailPanel](./components/detail-panel) | Labeled rows and grouped sections for quick facts. | Selected actor/item/quest overviews. |
-| [FilterBar](./components/filter-bar) | One-row action strip with normalized action signals. | Search bars, data browsers, multi-facet filters. |
-| [ToolBar](./components/tool-bar) | Godot-native action strip for primary commands. | Top-level app controls, view mode switches. |
-| [TimelineView](./components/timeline-view) | Gantt-style timeline with tracks, events, and "now" marker. | Incident timelines, quests, operations scheduling. |
-| [VirtualTableView](./components/virtual-table-view) | Virtualized grid for massive datasets. | Logs, inventories, metrics, large tables. |
-| [RelationshipGraphView](./components/relationship-graph-view) | Pan/zoom node graph with draggable cards and edges. | Quest flows, transaction graphs, faction ties. |
-| [WaterfallView](./components/waterfall-view) | Cumulative step visualization from start to finish. | Economy deltas, budgets, scoring breakdowns. |
-| [EntityCard](./components/entity-card) | Reusable card element for nodes or panels. | Graph nodes, sidebars, list entries. |
+| [BarChartView](/docs/toolkits/godot-dataviz/components/bar-chart-view) | Grouped or stacked bar charts with labels, tooltips, and palette controls. | Dashboards, comparisons, KPIs across factions or regions. |
+| [BoxPlotView](/docs/toolkits/godot-dataviz/components/box-plot-view) | Box & whisker plots with optional outliers and auto quartiles. | Simulation outputs, loot variability, balance testing. |
+| [HistogramView](/docs/toolkits/godot-dataviz/components/histogram-view) | Fast binning, density fills, and marker lines. | Damage distributions, runtime metrics, economy simulations. |
+| [HeatMapView](/docs/toolkits/godot-dataviz/components/heat-map-view) | Grid heatmaps with categorical axes and palette legends. | Pathfinding costs, supply & demand, AI affinity matrices. |
+| [LineChartView](/docs/toolkits/godot-dataviz/components/line-chart-view) | Multi-series time-series plotting with hover and segment selection. | Performance metrics, price history, health over time. |
+| [SparklineTile](/docs/toolkits/godot-dataviz/components/sparkline-tile) | Minimal sparkline for dense dashboards. | Trend badges, KPI cards, inline deltas. |
+| [KpiTile](/docs/toolkits/godot-dataviz/components/kpi-tile) | Headline metric tile with delta arrow and sparkline. | Revenue, player count, faction power. |
+| [DetailPanel](/docs/toolkits/godot-dataviz/components/detail-panel) | Labeled rows and grouped sections for quick facts. | Selected actor/item/quest overviews. |
+| [FilterBar](/docs/toolkits/godot-dataviz/components/filter-bar) | One-row action strip with normalized action signals. | Search bars, data browsers, multi-facet filters. |
+| [ToolBar](/docs/toolkits/godot-dataviz/components/tool-bar) | Godot-native action strip for primary commands. | Top-level app controls, view mode switches. |
+| [TimelineView](/docs/toolkits/godot-dataviz/components/timeline-view) | Gantt-style timeline with tracks, events, and "now" marker. | Incident timelines, quests, operations scheduling. |
+| [VirtualTableView](/docs/toolkits/godot-dataviz/components/virtual-table-view) | Virtualized grid for massive datasets. | Logs, inventories, metrics, large tables. |
+| [RelationshipGraphView](/docs/toolkits/godot-dataviz/components/relationship-graph-view) | Pan/zoom node graph with draggable cards and edges. | Quest flows, transaction graphs, faction ties. |
+| [WaterfallView](/docs/toolkits/godot-dataviz/components/waterfall-view) | Cumulative step visualization from start to finish. | Economy deltas, budgets, scoring breakdowns. |
+| [EntityCard](/docs/toolkits/godot-dataviz/components/entity-card) | Reusable card element for nodes or panels. | Graph nodes, sidebars, list entries. |
 
 ## Common features
 


### PR DESCRIPTION
## Summary
- fix toolkit overview table to link to the correct component doc paths
- update every component page footer to return to the Godot DataViz overview using a working link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d4092dd0fc83269af4236be46ec080